### PR TITLE
Change the method of match data-col attribute for exact match

### DIFF
--- a/multifilter.js
+++ b/multifilter.js
@@ -6,8 +6,8 @@
       'method'    : 'thead' // This can be thead or class
     }, options);
 
-    jQuery.expr[":"].Contains = function(a, i, m) {
-      return (a.textContent || a.innerText || "").toUpperCase().indexOf(m[3].toUpperCase()) >= 0;
+    jQuery.expr[":"].Equals = function(a, i, m) {
+      return (a.textContent || a.innerText || "").toUpperCase() === m[3].toUpperCase();
     };
 
     this.each(function() {
@@ -19,7 +19,7 @@
 
       if (settings.method === 'thead') {
         // Match the data-col attribute to the text in the thead
-        var col = container.find('th:Contains(' + $this.data('col') + ')');
+        var col = container.find('th:Equals(' + $this.data('col') + ')');
         var col_index = container.find($('thead th')).index(col);
       };
 


### PR DESCRIPTION
indexOf method is good for whether there is a specific string or not.
But it doesn't work for exact match.

Ex.

``` HTML
<li><input type="text" name="" class="filter" data-col="very-good" ></li>
<li><input type="text" name="" class="filter" data-col="good" ></li>
```

``` HTML
<tr>
    <th>very-good</th>
    <th>good</th>
</tr>
```

In this case, "good" column doesn't work. 
Because indexOf method can match "good" and "very-good".
So, I change the method for it.
Could you please review this PR if you have time.
